### PR TITLE
Fix hydration of data on client-side.

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -127,7 +127,7 @@ export function loadPropsOnServer({ components, params }, cb) {
 function hydrate(props) {
   if (typeof __ASYNC_PROPS__ !== 'undefined')
     return {
-      propsArray: JSON.parse(__ASYNC_PROPS__),
+      propsArray: __ASYNC_PROPS__,
       componentsArray: filterAndFlattenComponents(props.components)
     }
   else

--- a/modules/__tests__/AsyncProps-test.js
+++ b/modules/__tests__/AsyncProps-test.js
@@ -236,7 +236,7 @@ describe('AsyncProps', () => {
       } ]
     }
 
-    beforeEach(() => window.__ASYNC_PROPS__ = JSON.stringify([ DATA ]))
+    beforeEach(() => window.__ASYNC_PROPS__ = [ DATA ])
     afterEach(() => delete window.__ASYNC_PROPS__ )
 
     it('renders synchronously with props from hydration', () => {


### PR DESCRIPTION
`loadPropsOnServer` creates a correct script tag on the server side, which sets the value of __ASYNC_PROPS__ to be an array. The client-side incorrectly tried to use `JSON.parse` on an array, which fails. The tests passed because they were actually setting __ASYNC_PROPS__ to be a JSON-string.